### PR TITLE
feat: add export to InteractiveCardHeaderTemplate and InteractiveCard…

### DIFF
--- a/typings/card.ts
+++ b/typings/card.ts
@@ -27,7 +27,7 @@ interface InteractiveCardConfig {
     wide_screen_mode?: boolean; // deprecated after 2021/03/22
 }
 
-type InteractiveCardHeaderTemplate =
+export type InteractiveCardHeaderTemplate =
     | 'blue'
     | 'wathet'
     | 'turquoise'
@@ -40,7 +40,7 @@ type InteractiveCardHeaderTemplate =
     | 'purple'
     | 'indigo'
     | 'grey';
-interface InteractiveCardHeader {
+export interface InteractiveCardHeader {
     title: InteractiveCardTitle;
     template?: InteractiveCardHeaderTemplate;
 }


### PR DESCRIPTION
…Header

我在 InteractiveCard 基础上定义了一些卡片类型，用 sdk 的时候发现 template 的类型没有导出，导致我必须自己定义一下。
<img width="659" alt="image" src="https://github.com/larksuite/node-sdk/assets/34255589/e0587f9c-4ff6-4aab-b84a-846a195cf80b">


不知道是不是有意这样做的？