### PR TITLE
feat: ws support proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuiteoapi/node-sdk",
-  "version": "1.51.0",
+  "version": "1.52.0",
   "description": "larksuite open sdk for nodejs",
   "keywords": [
     "feishu",

--- a/typings/http.ts
+++ b/typings/http.ts
@@ -1,5 +1,5 @@
 export interface HttpInstance {
-  request<T = any, R = T, D = any>(opts: HttpRequestOptions<D>): Promise<R>;
+	request<T = any, R = T, D = any>(opts: HttpRequestOptions<D>): Promise<R>;
 	get<T = any, R = T, D = any>(url: string, opts?: HttpRequestOptions<D>): Promise<R>;
 	delete<T = any, R = T, D = any>(url: string, opts?: HttpRequestOptions<D>): Promise<R>;
 	head<T = any, R = T, D = any>(url: string, opts?: HttpRequestOptions<D>): Promise<R>;


### PR DESCRIPTION
Pass the agent parameter to WebSocket to support accessing the target service through a proxy.

full example code:  https://github.com/larksuite/node-sdk/pull/145#issuecomment-3023439829
