### PR TITLE
docs(README): 修复文档中关于自定义适配器的使用说明及示例代码

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,15 +491,22 @@ const eventDispatcher = new lark.EventDispatcher({
 router.post('/webhook/event', lark.adaptKoaRouter(eventDispatcher));
 server.use(router.routes());
 server.listen(3000);
-````
+```
+
 #### Custom adapter
-If you want to adapt to services written by other libraries, you currently need to encapsulate the corresponding adapter yourself. Pass the received event data to the invoke method of the instantiated `eventDispatcher` for event processing:
+
+If you want to adapt to services written by other libraries, you currently need to encapsulate the corresponding adapter yourself. Pass the received event data and request headers to the invoke method of the instantiated `eventDispatcher` for event processing:
 
 ```typescript
 const data = server.getData();
-const result = await dispatcher.invoke(data);
+const headers = server.getHeaders();
+const assigned = Object.assign(
+  Object.create({ headers }),
+  data,
+);
+const result = await dispatcher.invoke(assigned);
 server.sendResult(result);
-````
+```
 
 #### Challenge check
 When configuring the event request address, The Open Platform will push a POST request in `application/json` format to the request address. The POST request is used to verify the validity of the configured request address, and the request body will carry a `challenge` field , **The application needs to return the received challenge value to the Open Platform within 1 second**. See: [ Document](https://open.feishu.cn/document/ukTMukTMukTM/uYDNxYjL2QTM24iN0EjN/event-subscription-configure-/request-url-configuration-case)

--- a/README.zh.md
+++ b/README.zh.md
@@ -492,12 +492,19 @@ router.post('/webhook/event', lark.adaptKoaRouter(eventDispatcher));
 server.use(router.routes());
 server.listen(3000);
 ```
+
 #### 自定义适配器
-如果要适配其它库编写的服务，目前需要自己来封装相应的适配器。将接收到的事件数据传递给实例化的`eventDispatcher`的invoke方法进行事件的处理即可：
+
+如果要适配其它库编写的服务，目前需要自己来封装相应的适配器。将接收到的事件数据和请求头传递给实例化的 `eventDispatcher` 的 invoke 方法进行事件的处理即可：
 
 ```typescript
 const data = server.getData();
-const result = await dispatcher.invoke(data);
+const headers = server.getHeaders();
+const assigned = Object.assign(
+  Object.create({ headers }),
+  data,
+);
+const result = await dispatcher.invoke(assigned);
 server.sendResult(result);
 ```
 


### PR DESCRIPTION
- 在其他适配器中有关于请求头的合并代码，如默认的 [http 模块适配器](https://github.com/larksuite/node-sdk/blob/main/adaptor/default.ts#L20)
- 如果自定义适配器未合并请求头到 `headers` 字段，会导致 [`checkIsEventValidated` 函数抛出错误](https://github.com/larksuite/node-sdk/blob/main/dispatcher/request-handle.ts#L108)，类似 [Issue #135](https://github.com/larksuite/node-sdk/issues/135) 提到的 `Cannot destructure property 'x-lark-request-timestamp' of 'data.headers' as it is undefined`
- 避免解构赋值导致的 Verification Failed 错误，见 [Issue #46](https://github.com/larksuite/node-sdk/issues/46#issuecomment-1519458274)