### PR TITLE
chore: add npm metadata links

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,14 @@
   },
   "author": "mazhe.nerd",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/larksuite/node-sdk.git"
+  },
   "homepage": "https://github.com/larksuite/node-sdk",
-  "url": "https://github.com/larksuite/node-sdk/issues",
+  "bugs": {
+    "url": "https://github.com/larksuite/node-sdk/issues"
+  },
   "dependencies": {
     "axios": "~1.13.3",
     "lodash.identity": "^3.0.0",


### PR DESCRIPTION
﻿## Summary

This updates the npm package metadata in `package.json`:

- adds the GitHub repository metadata
- replaces the non-standard top-level `url` field with standard `bugs.url`
- keeps the existing homepage link

No runtime code, dependencies, build config, or generated files are changed.

## Verification

- `node -e "const p=require('./package.json'); if (p.repository?.url !== 'https://github.com/larksuite/node-sdk.git' || p.bugs?.url !== 'https://github.com/larksuite/node-sdk/issues' || Object.prototype.hasOwnProperty.call(p,'url')) process.exit(1)"`
- `git diff --cached --check`
- `npm pack --dry-run --json --ignore-scripts`
- `corepack yarn install --frozen-lockfile --ignore-scripts`
- `corepack yarn build` completed successfully on Windows; it prints existing TypeScript/Rollup warnings and a Windows `rm` warning, but exits 0.
- WSL Ubuntu 26.04:
  - `npm pkg get repository homepage bugs --json`
  - `npm pack --dry-run --json --ignore-scripts`

I also tried `corepack yarn test --runInBand`; it did not complete within 5 minutes in my local Windows run, so I stopped the leftover Jest process. This change is limited to package metadata.
