### PR TITLE
fix: rethrow token request failures in TokenManager (#182)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ local-tests
 
 # jest coverage reports
 coverage
+
+# oapi-harness local task state & sandbox run artifacts
+.harness/
+.harness-sandbox-result.json

--- a/client/__tests__/token-manager.test.ts
+++ b/client/__tests__/token-manager.test.ts
@@ -1,0 +1,244 @@
+import { TokenManager } from '../token-manager';
+import { AppType, Cache, Logger } from '@node-sdk/typings';
+import { CTenantAccessToken, CAppTicket } from '@node-sdk/consts';
+
+const DOMAIN = 'https://open.feishu.cn';
+const APP_ID = 'cli_test_app';
+
+function makeLogger(): Logger {
+    return {
+        error: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+        debug: jest.fn(),
+        trace: jest.fn(),
+    };
+}
+
+// In-memory cache keyed by `${String(key)}|${namespace}`.
+function makeCache(initial: Array<[string | Symbol, any, string?]> = []): Cache & {
+    set: jest.Mock;
+    get: jest.Mock;
+} {
+    const store = new Map<string, any>();
+    const k = (key: string | Symbol, namespace?: string) =>
+        `${String(key)}|${namespace ?? ''}`;
+    for (const [key, value, namespace] of initial) {
+        store.set(k(key, namespace), value);
+    }
+    const set = jest.fn(
+        async (key: string | Symbol, value: any, _expire?: number, options?: { namespace?: string }) => {
+            store.set(k(key, options?.namespace), value);
+            return true;
+        }
+    );
+    const get = jest.fn(async (key: string | Symbol, options?: { namespace?: string }) => {
+        return store.get(k(key, options?.namespace));
+    });
+    return { set, get };
+}
+
+// post mock routed by URL substring.
+function makeHttp(routes: Record<string, () => Promise<any>>): { post: jest.Mock } {
+    const post = jest.fn(async (url: string) => {
+        const match = Object.keys(routes).find((frag) => url.includes(frag));
+        if (!match) {
+            throw new Error(`unexpected POST to ${url}`);
+        }
+        return routes[match]();
+    });
+    return { post };
+}
+
+function makeManager(opts: {
+    appType: AppType;
+    cache: Cache;
+    http: { post: jest.Mock };
+    logger?: Logger;
+    appSecret?: string;
+}) {
+    return new TokenManager({
+        appId: APP_ID,
+        appSecret: opts.appSecret ?? 'app_secret_value',
+        cache: opts.cache,
+        domain: DOMAIN,
+        logger: opts.logger ?? makeLogger(),
+        appType: opts.appType,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        httpInstance: opts.http as any,
+    });
+}
+
+afterEach(() => {
+    jest.useRealTimers();
+});
+
+describe('TokenManager · getCustomTenantAccessToken (self-build)', () => {
+    test('rethrows the original transport error instead of a secondary destructure error', async () => {
+        const logger = makeLogger();
+        const cache = makeCache();
+        const http = makeHttp({
+            'tenant_access_token/internal': () => Promise.reject(new Error('EPIPE')),
+        });
+        const tm = makeManager({ appType: AppType.SelfBuild, cache, http, logger });
+
+        await expect(tm.getCustomTenantAccessToken()).rejects.toThrow('EPIPE');
+        await expect(tm.getCustomTenantAccessToken()).rejects.not.toThrow(
+            /Cannot destructure property/
+        );
+        expect(cache.set).not.toHaveBeenCalled();
+        expect(logger.error).toHaveBeenCalled();
+    });
+
+    test('throws on business error (no token field) and does not cache', async () => {
+        const cache = makeCache();
+        const http = makeHttp({
+            'tenant_access_token/internal': () =>
+                Promise.resolve({ code: 99991663, msg: 'app ticket invalid' }),
+        });
+        const tm = makeManager({ appType: AppType.SelfBuild, cache, http });
+
+        const err = await tm.getCustomTenantAccessToken().then(
+            () => null,
+            (e) => e
+        );
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toContain('99991663');
+        expect(err.message).toContain('app ticket invalid');
+        expect(cache.set).not.toHaveBeenCalled();
+    });
+
+    test('success path is unchanged: returns token and caches with 3-min-earlier expiry', async () => {
+        const cache = makeCache();
+        const http = makeHttp({
+            'tenant_access_token/internal': () =>
+                Promise.resolve({ code: 0, tenant_access_token: 't-xxx', expire: 7200 }),
+        });
+        const tm = makeManager({ appType: AppType.SelfBuild, cache, http });
+
+        const before = Date.now();
+        const token = await tm.getCustomTenantAccessToken();
+        const after = Date.now();
+
+        expect(token).toBe('t-xxx');
+        expect(cache.set).toHaveBeenCalledTimes(1);
+        const [key, value, expiry, options] = (cache.set as jest.Mock).mock.calls[0];
+        expect(key).toBe(CTenantAccessToken);
+        expect(value).toBe('t-xxx');
+        expect(options).toEqual({ namespace: APP_ID });
+        const offset = 7200 * 1000 - 3 * 60 * 1000;
+        expect(expiry).toBeGreaterThanOrEqual(before + offset);
+        expect(expiry).toBeLessThanOrEqual(after + offset);
+    });
+
+    test('cache hit short-circuits without any request', async () => {
+        const cache = makeCache([[CTenantAccessToken, 'cached-t', APP_ID]]);
+        const http = makeHttp({});
+        const tm = makeManager({ appType: AppType.SelfBuild, cache, http });
+
+        await expect(tm.getCustomTenantAccessToken()).resolves.toBe('cached-t');
+        expect(http.post).not.toHaveBeenCalled();
+    });
+
+    test('business-error message does not leak credentials', async () => {
+        const cache = makeCache();
+        const http = makeHttp({
+            'tenant_access_token/internal': () => Promise.resolve({ code: 1, msg: 'bad' }),
+        });
+        const tm = makeManager({
+            appType: AppType.SelfBuild,
+            cache,
+            http,
+            appSecret: 'SUPER_SECRET_xyz',
+        });
+
+        const err = await tm.getCustomTenantAccessToken().then(
+            () => null,
+            (e) => e
+        );
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).not.toContain('SUPER_SECRET_xyz');
+    });
+});
+
+describe('TokenManager · getMarketTenantAccessToken (ISV)', () => {
+    test('rethrows transport error from app_access_token request and does not cache', async () => {
+        const cache = makeCache([[CAppTicket, 'ticket-1', APP_ID]]);
+        const http = makeHttp({
+            'auth/v3/app_access_token': () => Promise.reject(new Error('ETIMEDOUT')),
+        });
+        const tm = makeManager({ appType: AppType.ISV, cache, http });
+
+        await expect(tm.getMarketTenantAccessToken('tk')).rejects.toThrow('ETIMEDOUT');
+        expect(cache.set).not.toHaveBeenCalledWith(
+            'larkMarketAccessTokentk',
+            expect.anything(),
+            expect.anything(),
+            expect.anything()
+        );
+    });
+
+    test('throws when tenant_access_token field missing and does not cache', async () => {
+        const cache = makeCache([[CAppTicket, 'ticket-1', APP_ID]]);
+        const http = makeHttp({
+            'auth/v3/app_access_token': () =>
+                Promise.resolve({ code: 0, app_access_token: 'a-xxx' }),
+            'auth/v3/tenant_access_token': () => Promise.resolve({ code: 1, msg: 'boom' }),
+        });
+        const tm = makeManager({ appType: AppType.ISV, cache, http });
+
+        const err = await tm.getMarketTenantAccessToken('tk').then(
+            () => null,
+            (e) => e
+        );
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toContain('1');
+        expect(err.message).toContain('boom');
+        expect(cache.set).not.toHaveBeenCalledWith(
+            'larkMarketAccessTokentk',
+            expect.anything(),
+            expect.anything(),
+            expect.anything()
+        );
+    });
+
+    test('success path is unchanged: returns tenant token and caches it', async () => {
+        const cache = makeCache([[CAppTicket, 'ticket-1', APP_ID]]);
+        const http = makeHttp({
+            'auth/v3/app_access_token': () =>
+                Promise.resolve({ code: 0, app_access_token: 'a-xxx' }),
+            'auth/v3/tenant_access_token': () =>
+                Promise.resolve({ code: 0, tenant_access_token: 't-yyy', expire: 7200 }),
+        });
+        const tm = makeManager({ appType: AppType.ISV, cache, http });
+
+        const before = Date.now();
+        const token = await tm.getMarketTenantAccessToken('tk');
+        const after = Date.now();
+
+        expect(token).toBe('t-yyy');
+        const setCall = (cache.set as jest.Mock).mock.calls.find(
+            (c) => c[0] === 'larkMarketAccessTokentk'
+        );
+        expect(setCall).toBeDefined();
+        const [, value, expiry, options] = setCall;
+        expect(value).toBe('t-yyy');
+        expect(options).toEqual({ namespace: APP_ID });
+        const offset = 7200 * 1000 - 3 * 60 * 1000;
+        expect(expiry).toBeGreaterThanOrEqual(before + offset);
+        expect(expiry).toBeLessThanOrEqual(after + offset);
+    });
+
+    test('cache hit short-circuits without token request', async () => {
+        // seed CAppTicket too so the constructor's checkAppTicket() does not fire a resend POST
+        const cache = makeCache([
+            ['larkMarketAccessTokentk', 'cached-m', APP_ID],
+            [CAppTicket, 'ticket-1', APP_ID],
+        ]);
+        const http = makeHttp({});
+        const tm = makeManager({ appType: AppType.ISV, cache, http });
+
+        await expect(tm.getMarketTenantAccessToken('tk')).resolves.toBe('cached-m');
+        expect(http.post).not.toHaveBeenCalled();
+    });
+});

--- a/client/token-manager.ts
+++ b/client/token-manager.ts
@@ -14,6 +14,23 @@ interface IParams {
     httpInstance: HttpInstance;
 }
 
+interface TokenResponse {
+    code?: number | string;
+    msg?: string;
+}
+
+/**
+ * Build an error message for a token response that is missing its expected
+ * field. Only the API's own `code`/`msg` are echoed back — never request
+ * credentials (app_secret, app_ticket, tokens) — so the message is safe to
+ * surface to callers and logs.
+ */
+function buildTokenError(field: string, response?: TokenResponse): string {
+    const code = response?.code ?? 'unknown';
+    const msg = response?.msg ?? 'no message';
+    return `failed to get ${field}, code: ${code}, msg: ${msg}`;
+}
+
 export class TokenManager {
     appId: string;
 
@@ -53,6 +70,34 @@ export class TokenManager {
         this.logger.debug('token manager is ready');
     }
 
+    /**
+     * POST a token endpoint and return the validated response body.
+     *
+     * On transport failure the original error is logged and rethrown — so the
+     * caller sees the real cause (EPIPE, timeout, ...) instead of a secondary
+     * "Cannot destructure ... of undefined". On an HTTP-200 business failure the
+     * required field is absent; we throw an error carrying only the API's
+     * code/msg and never cache an undefined token.
+     */
+    private async requestToken<T extends Record<string, unknown>>(
+        url: string,
+        body: Record<string, unknown>,
+        requiredField: Extract<keyof T, string>
+    ): Promise<T & TokenResponse> {
+        const response = await this.httpInstance
+            .post<T & TokenResponse>(url, body)
+            .catch((e) => {
+                this.logger.error(e);
+                throw e;
+            });
+
+        if (!response || !response[requiredField]) {
+            throw new Error(buildTokenError(requiredField, response));
+        }
+
+        return response;
+    }
+
     async getCustomTenantAccessToken() {
         const cachedTenantAccessToken = await this.cache?.get(
             CTenantAccessToken,
@@ -67,24 +112,23 @@ export class TokenManager {
         }
 
         this.logger.debug('request token');
-        // @ts-ignore
-        const { tenant_access_token, expire } = await this.httpInstance
-            .post(
-                `${this.domain}/open-apis/auth/v3/tenant_access_token/internal`,
-                {
-                    app_id: this.appId,
-                    app_secret: this.appSecret,
-                }
-            )
-            .catch((e) => {
-                this.logger.error(e);
-            });
+        const { tenant_access_token, expire } = await this.requestToken<{
+            tenant_access_token?: string;
+            expire?: number;
+        }>(
+            `${this.domain}/open-apis/auth/v3/tenant_access_token/internal`,
+            {
+                app_id: this.appId,
+                app_secret: this.appSecret,
+            },
+            'tenant_access_token'
+        );
 
         await this.cache?.set(
             CTenantAccessToken,
             tenant_access_token,
             // Due to the time-consuming network, the expiration time needs to be 3 minutes earlier
-            new Date().getTime() + expire * 1000 - 3 * 60 * 1000,
+            new Date().getTime() + expire! * 1000 - 3 * 60 * 1000,
             {
                 namespace: this.appId
             }
@@ -121,37 +165,38 @@ export class TokenManager {
 
         this.logger.debug('get app access token');
         // 获取app_access_token
-        // @ts-ignore
-        const { app_access_token } = await this.httpInstance
-            .post<{
-                app_access_token: string;
-            }>(`${this.domain}/open-apis/auth/v3/app_access_token`, {
+        const { app_access_token } = await this.requestToken<{
+            app_access_token?: string;
+        }>(
+            `${this.domain}/open-apis/auth/v3/app_access_token`,
+            {
                 app_id: this.appId,
                 app_secret: this.appSecret,
                 app_ticket: appTicket,
-            })
-            .catch((e) => {
-                this.logger.error(e);
-            });
+            },
+            'app_access_token'
+        );
 
         this.logger.debug('get tenant access token');
         // 获取tenant_access_token
-        // @ts-ignore
-        const { tenant_access_token, expire } = await this.httpInstance
-            .post(`${this.domain}/open-apis/auth/v3/tenant_access_token`, {
+        const { tenant_access_token, expire } = await this.requestToken<{
+            tenant_access_token?: string;
+            expire?: number;
+        }>(
+            `${this.domain}/open-apis/auth/v3/tenant_access_token`,
+            {
                 app_access_token,
                 tenant_key: tenantKey,
-            })
-            .catch((e) => {
-                this.logger.error(e);
-            });
+            },
+            'tenant_access_token'
+        );
 
         // 设置tenant_access_token
         await this.cache.set(
             `larkMarketAccessToken${tenantKey}`,
             tenant_access_token,
             // Due to the time-consuming network, the expiration time needs to be 3 minutes earlier
-            new Date().getTime() + expire * 1000 - 3 * 60 * 1000,
+            new Date().getTime() + expire! * 1000 - 3 * 60 * 1000,
             {
                 namespace: this.appId
             }

--- a/client/utils/__tests__/format-errors.ts
+++ b/client/utils/__tests__/format-errors.ts
@@ -21,7 +21,9 @@ describe('formatErrors', () => {
             {
                 headers: {},
                 config: {},
-                data: 'response-data',
+                // A real Feishu error body is an object; formatErrors spreads it
+                // (and merges a nested `error` field) into the appended entry.
+                data: { code: 400, msg: 'response-msg' },
                 status: 400,
                 statusText: 'response-statusText',
             }
@@ -43,12 +45,12 @@ describe('formatErrors', () => {
                     method: 'request-method',
                 },
                 response: {
-                    data: 'response-data',
+                    data: { code: 400, msg: 'response-msg' },
                     status: 400,
                     statusText: 'response-statusText',
                 },
             },
-            'response-data',
+            { code: 400, msg: 'response-msg' },
         ]);
     });
 

--- a/ws-client/__tests__/data-cache.ts
+++ b/ws-client/__tests__/data-cache.ts
@@ -1,6 +1,10 @@
 import { DataCache } from '../data-cache';
 
 describe('DataCache', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   test('mergeData is right when sum = 1', () => {
     const dataCache = new DataCache({});
     const text = '{"data":"hello,world"}';
@@ -49,8 +53,10 @@ describe('DataCache', () => {
   });
 
   test('data is expired', () => {
-    jest.useFakeTimers();
-  
+    // doNotFake performance: @sinonjs/fake-timers cannot hijack the read-only
+    // global `performance` on newer Node, which otherwise throws on install.
+    jest.useFakeTimers({ doNotFake: ['performance'] });
+
     const dataCache = new DataCache({});
     const text = '{"data":"hello,world"}';
 
@@ -70,8 +76,10 @@ describe('DataCache', () => {
   });
 
   test('data is lived', () => {
-    jest.useFakeTimers();
-  
+    // doNotFake performance: @sinonjs/fake-timers cannot hijack the read-only
+    // global `performance` on newer Node, which otherwise throws on install.
+    jest.useFakeTimers({ doNotFake: ['performance'] });
+
     const dataCache = new DataCache({});
     const text = '{"data":"hello,world"}';
 


### PR DESCRIPTION
## What

`TokenManager.getCustomTenantAccessToken` / `getMarketTenantAccessToken` caught HTTP failures only to log them, then destructured the `undefined` result — turning a transport error (EPIPE / timeout / reset) into a misleading secondary `Cannot destructure property 'tenant_access_token' of undefined`, and caching an `undefined` token.

## Changes

- Log then **rethrow** the original error so the real failure surfaces to the caller.
- **Validate** the response before destructuring; throw a clear error carrying the Feishu `code`/`msg` when a token field is missing. Error messages echo only `code`/`msg`, never credentials.
- **Cache only after** a valid token is obtained — never an `undefined` value.
- Extract a private `requestToken()` so the three token POSTs share one fetch + validate path.

## Behavior

- Success path, cache key, namespace, and the 3-minute-early expiry are unchanged.
- On failure the methods now throw a meaningful error instead of returning `undefined` / throwing a destructure `TypeError`.

## Tests

- New unit suite `client/__tests__/token-manager.test.ts` (9 cases) covering transport-failure rethrow, business-error throw, no-credential-leak, success paths, and cache-hit short-circuit for both self-build and ISV.
- Also fixes two pre-existing baseline test failures (`format-errors`, `data-cache`) that were red on `main`.

Closes #182