### PR TITLE
fix(ws-client): unref DataCache sweep timer and clean it up on close

### DIFF
--- a/ws-client/__tests__/data-cache.ts
+++ b/ws-client/__tests__/data-cache.ts
@@ -93,9 +93,75 @@ describe('DataCache', () => {
 
     dataCache.mergeData(mockData);
 
-    jest.advanceTimersByTime(1000 * 5); 
-    
+    jest.advanceTimersByTime(1000 * 5);
+
     expect(dataCache.cache.get('message_id')).not.toBeUndefined();
+  });
+
+  // The sweep timer must not, on its own, keep the Node process alive — this is
+  // the issue #193 regression: a non-unref'd setInterval blocked process exit.
+  // Stub setInterval to a handle whose unref is observable, so the assertion
+  // genuinely fails if the production code stops calling unref().
+  test('sweep timer is unref-ed so it does not block process exit', () => {
+    const unref = jest.fn();
+    const setIntervalSpy = jest
+      .spyOn(global, 'setInterval')
+      .mockReturnValue({ unref } as unknown as ReturnType<typeof setInterval>);
+
+    new DataCache({});
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(unref).toHaveBeenCalledTimes(1);
+
+    setIntervalSpy.mockRestore();
+  });
+
+  // destroy() stops the sweep and frees cached fragments, so WSClient.close()
+  // can release its event-loop handle.
+  test('destroy stops the sweep and clears the cache', () => {
+    jest.useFakeTimers({ doNotFake: ['performance'] });
+
+    const dataCache = new DataCache({});
+    dataCache.mergeData({
+      message_id: 'message_id',
+      sum: 2,
+      seq: 0,
+      trace_id: 'trace_id',
+      data: new TextEncoder().encode('{"data":"hello,')
+    });
+
+    dataCache.destroy();
+    expect(dataCache.cache.size).toBe(0);
+
+    // Re-populate, then advance past the expiry window: a stopped sweep must
+    // not delete it, proving the interval is truly cleared.
+    dataCache.cache.set('lingering', {
+      buffer: [],
+      trace_id: 'trace_id',
+      message_id: 'lingering',
+      create_time: Date.now()
+    });
+    jest.advanceTimersByTime(10000 * 2 + 100);
+    expect(dataCache.cache.get('lingering')).not.toBeUndefined();
+  });
+
+  // clearAtInterval() is idempotent (constructor already armed it) and can
+  // re-arm after destroy(), so close()->start() reuse keeps expiry working.
+  test('clearAtInterval is idempotent and re-arms after destroy', () => {
+    jest.useFakeTimers({ doNotFake: ['performance'] });
+    const setIntervalSpy = jest.spyOn(global, 'setInterval');
+
+    const dataCache = new DataCache({});
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+    // Already running: a second call must not create a second timer.
+    dataCache.clearAtInterval();
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+    // After destroy() it must be possible to re-arm.
+    dataCache.destroy();
+    dataCache.clearAtInterval();
+    expect(setIntervalSpy).toHaveBeenCalledTimes(2);
   });
 
 })

--- a/ws-client/data-cache.ts
+++ b/ws-client/data-cache.ts
@@ -9,7 +9,9 @@ export class DataCache {
   }>
 
   logger?: Logger;
-  
+
+  private timer?: ReturnType<typeof setInterval>;
+
   constructor(params: {
     logger?: Logger;
   }) {
@@ -66,10 +68,15 @@ export class DataCache {
     this.cache.delete(message_id);
   }
 
-  private clearAtInterval() {
+  // Idempotent: re-arming an already-running sweep is a no-op, so it is safe
+  // to call again on start() after a previous destroy().
+  clearAtInterval() {
+    if (this.timer) {
+      return;
+    }
     // magic number，10s expired
     const clearIntervalMs = 10000;
-    setInterval(() => {
+    this.timer = setInterval(() => {
       const now = Date.now();
       this.cache.forEach((value, key) => {
         const { create_time, trace_id, message_id } = value;
@@ -79,6 +86,21 @@ export class DataCache {
         }
       });
     }, clearIntervalMs);
+    // Don't let the sweep timer keep the Node process alive on its own; the
+    // process should be free to exit once nothing else references the loop.
+    if (typeof this.timer.unref === 'function') {
+      this.timer.unref();
+    }
+  }
+
+  // Stop the sweep timer and drop cached fragments. Called from
+  // WSClient.close() so the client releases its event-loop handle.
+  destroy() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+    this.cache.clear();
   }
 }
 

--- a/ws-client/index.ts
+++ b/ws-client/index.ts
@@ -635,6 +635,7 @@ export class WSClient {
       this.reconnectInterval = undefined;
     }
     this.clearLiveness();
+    this.dataCache.destroy();
     this.isConnecting = false;
     this.currentReconnectAttempts = 0;
     const wsInstance = this.wsConfig.getWSInstance();
@@ -667,6 +668,9 @@ export class WSClient {
     // getConnectionStatus() reflects the fresh start.
     this.terminalError = false;
     this.currentReconnectAttempts = 0;
+    // Re-arm the cache sweep in case the client was previously close()d
+    // (which destroys the timer); idempotent when already running.
+    this.dataCache.clearAtInterval();
 
     this.logger.info(
       '[ws]',


### PR DESCRIPTION
## What

Fixes #193 — `DataCache`'s 10s `setInterval` (the expired-fragment sweep) kept the Node event loop referenced, so processes using the long-connection `WSClient` could not exit on their own even after `WSClient.close()`.

## Changes

- **`ws-client/data-cache.ts`**
  - Store the interval handle and call `unref()` on it (guarded) so the sweep timer never blocks process exit on its own — this is the root-cause fix.
  - `clearAtInterval()` is now idempotent (re-arming an already-running sweep is a no-op) and made `public`.
  - New `destroy()`: `clearInterval` the sweep, drop the handle, and `cache.clear()` to release buffered fragments.
- **`ws-client/index.ts`**
  - `close()` now calls `dataCache.destroy()` for explicit lifecycle cleanup.
  - `start()` re-arms via `dataCache.clearAtInterval()` so a `close()` → `start()` reuse of the same client keeps expiry working (idempotent when already running).
- **Tests** — added unit tests covering: timer is `unref`-ed, `destroy()` stops the sweep and clears the cache, and `clearAtInterval()` is idempotent / re-arms after `destroy()`.

## Verification

- Unit: full suite green (392/392), including the 3 new cases.
- Manual process-level e2e: a child process constructing `WSClient` exits naturally (`code=0`) both with and without an explicit `close()`; a non-unref'd-interval negative control hangs as expected, confirming the test isn't vacuous.
- No change to the public `WSClient` API surface; auto-reconnect path is untouched (`destroy()` only runs on manual `close()`).