### PR TITLE
feat(registration): support preset field in registerApp addons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuiteoapi/node-sdk",
-  "version": "1.68.0",
+  "version": "1.69.0",
   "description": "larksuite open sdk for nodejs",
   "keywords": [
     "feishu",

--- a/scene/registration/__tests__/addons.ts
+++ b/scene/registration/__tests__/addons.ts
@@ -93,4 +93,47 @@ describe('encodeAddons', () => {
         expect(() => encodeAddons('x' as unknown as AppAddons)).toThrow(/addons must be an object/);
         expect(() => encodeAddons([] as unknown as AppAddons)).toThrow(/addons must be an object/);
     });
+
+    test('passes preset:true through alongside the declared sections', () => {
+        const addons: AppAddons = { preset: true, scopes: { tenant: ['im:message:send_as_bot'] } };
+        expect(decode(encodeAddons(addons))).toEqual({
+            preset: true,
+            scopes: { tenant: ['im:message:send_as_bot'] },
+        });
+    });
+
+    test('passes preset:false through alongside the declared sections', () => {
+        const addons: AppAddons = { preset: false, scopes: { tenant: ['im:message:send_as_bot'] } };
+        expect(decode(encodeAddons(addons))).toEqual({
+            preset: false,
+            scopes: { tenant: ['im:message:send_as_bot'] },
+        });
+    });
+
+    test('allows preset:false with zero addon sections (minimal base, no declarations)', () => {
+        expect(decode(encodeAddons({ preset: false }))).toEqual({ preset: false });
+    });
+
+    test('throws on preset:true with zero addon sections (preset does not exempt the empty-payload rule)', () => {
+        expect(() => encodeAddons({ preset: true })).toThrow(/at least one scope, event or callback/);
+    });
+
+    test('still requires at least one section when preset is absent', () => {
+        const match = /at least one scope, event or callback/;
+        expect(() => encodeAddons({})).toThrow(match);
+        expect(() => encodeAddons({ scopes: {} })).toThrow(match);
+    });
+
+    test('does not inject a preset key when preset is not provided', () => {
+        const decoded = decode(encodeAddons({ scopes: { tenant: ['x'] } })) as Record<string, unknown>;
+        expect(decoded).not.toHaveProperty('preset');
+    });
+
+    test('throws on non-boolean preset, validated before the empty-payload check', () => {
+        // 'false' must not slip past as truthy/`!== false` and bypass the empty-payload rule;
+        // the type check has to run first, so each of these fails on preset, not on emptiness.
+        expect(() => encodeAddons({ preset: 'false' } as any)).toThrow(/addons\.preset/);
+        expect(() => encodeAddons({ preset: 0 } as any)).toThrow(/addons\.preset/);
+        expect(() => encodeAddons({ preset: null } as any)).toThrow(/addons\.preset/);
+    });
 });

--- a/scene/registration/addons.ts
+++ b/scene/registration/addons.ts
@@ -45,12 +45,13 @@ function validateStringArray(value: unknown, path: string): string[] | undefined
 }
 
 /**
- * Validate the shape of `addons` and rebuild it from the 5 known public
- * fields only, so nothing outside the whitelist can ever be serialized.
+ * Validate the shape of `addons` and rebuild it from the known public
+ * fields only (`preset` / `scopes` / `events` / `callbacks`), so nothing
+ * outside the whitelist can ever be serialized.
  */
 function normalizeAddons(addons: AppAddons): AppAddons {
     assertPlainObject(addons, 'addons');
-    assertAllowedKeys(addons, ['scopes', 'events', 'callbacks'], 'addons');
+    assertAllowedKeys(addons, ['preset', 'scopes', 'events', 'callbacks'], 'addons');
 
     let itemCount = 0;
     const pick = (value: unknown, path: string): string[] | undefined => {
@@ -60,6 +61,16 @@ function normalizeAddons(addons: AppAddons): AppAddons {
     };
 
     const normalized: AppAddons = {};
+
+    // Validate `preset` before the empty-payload check below: a non-boolean
+    // (e.g. the string 'false') must throw here rather than slip past the
+    // `preset !== false` relaxation, and only the validated boolean is copied.
+    if (addons.preset !== undefined) {
+        if (typeof addons.preset !== 'boolean') {
+            throw new Error('addons.preset must be a boolean');
+        }
+        normalized.preset = addons.preset;
+    }
 
     if (addons.scopes !== undefined) {
         assertPlainObject(addons.scopes, 'addons.scopes');
@@ -94,8 +105,10 @@ function normalizeAddons(addons: AppAddons): AppAddons {
     }
 
     // An all-empty addons is treated as "no addons" by the confirm page —
-    // passing one is always a caller bug, so surface it at build time.
-    if (itemCount === 0) {
+    // passing one is normally a caller bug, so surface it at build time. The
+    // exception is `preset: false`, which is a meaningful payload on its own
+    // (minimal base template, zero increments).
+    if (itemCount === 0 && addons.preset !== false) {
         throw new Error(
             'addons must contain at least one scope, event or callback'
         );

--- a/scene/registration/types.ts
+++ b/scene/registration/types.ts
@@ -45,6 +45,17 @@ export interface AppPreset {
  *   otherwise the whole param is ignored and the default flow is used.
  */
 export interface AppAddons {
+    /**
+     * Template base selector, carried as the top-level `preset` field inside
+     * the encoded addons payload (parsed by the confirm page, not the backend).
+     * - `true` / omitted: keep the platform default template and layer the
+     *   declared scopes / events / callbacks on top (additive — same as before).
+     * - `false`: drop the default template, use the minimal base (bot capability
+     *   only, no business scopes) and show only the explicitly declared items.
+     *   With `preset: false` an otherwise-empty addons is valid (minimal base,
+     *   zero increments); without it at least one item is still required.
+     */
+    preset?: boolean;
     /** Permission scopes. */
     scopes?: {
         /** App-identity (tenant) scopes, e.g. `'im:message:send_as_bot'`. */


### PR DESCRIPTION
## 改动

为 `registerApp` 的 `addons` 配置新增顶层布尔字段 `preset`，用于选择创建应用时使用的模板底座。

- `AppAddons` 新增可选 `preset?: boolean`：
  - `true` / 缺省：保留平台默认模板，叠加声明的 scopes / events / callbacks（与既有行为一致）。
  - `false`：切到最小基础模板底座，只展示显式声明的项。
- `normalizeAddons` / `encodeAddons`：
  - `preset` 加入顶层键白名单；非 boolean 抛 `addons.preset must be a boolean`，校验先于空载判断（防 `'false'` 绕过），仅透传验证后的 boolean。
  - 空载校验放宽：`preset: false` 时允许零增量；其余情况仍要求至少一项。
- `preset` 经 gzip+base64url 编码进 `addons` query；URL 不新增独立参数，提交链路零改动。

## 兼容性

向后兼容：不传 `preset` 时归一化输出不含 `preset` 键、空载仍要求至少一项，行为与改动前一致。`AppAddons` 已对外导出，新增可选字段不破坏既有调用方。

## 验收

新增 7 个单测覆盖：true/false 透传 round-trip、`preset:false` 零增量合法、`preset:true`/缺省零增量仍报错、缺省不注入、非 boolean 报错（含校验顺序）、无 preset 回归。
build 通过、全量单测 399 全绿；e2e 装本地包在沙箱验证 `preset:false` 正确编码进创建链路 URL。
