### PR TITLE
fix(ws-client): handle late errors when aborting connecting sockets

### DIFF
--- a/ws-client/__tests__/reconnect.ts
+++ b/ws-client/__tests__/reconnect.ts
@@ -79,7 +79,13 @@ jest.mock('ws', () => {
     send(_data: any, cb?: (err?: Error) => void) {
       cb?.();
     }
-    close() {}
+    // Real `ws` routes close() on a non-OPEN socket through abortHandshake()
+    // too, so it emits the same late error as terminate().
+    close = jest.fn(() => {
+      if (this.readyState === CONNECTING) {
+        setImmediate(() => this.emit('error', new Error('WebSocket was closed before the connection was established')));
+      }
+    });
   }
   return { __esModule: true, default: MockWebSocket };
 });
@@ -130,37 +136,96 @@ function createMockHttpInstance() {
 // Tests
 // ---------------------------------------------------------------------------
 
+// `MockWebSocket.instances` is a module-level array that would otherwise grow
+// across tests — including from reconnect loops still running after a test
+// returns — making any `instances[n]` index unreliable.
+beforeEach(() => {
+  jest.requireMock('ws').default.instances.length = 0;
+});
+
 describe('WSClient reconnect timer leak (#177)', () => {
-  function createClient(httpMock: ReturnType<typeof createMockHttpInstance>) {
+  function createClient(
+    httpMock: ReturnType<typeof createMockHttpInstance>,
+    overrides: Record<string, unknown> = {},
+  ) {
     return new WSClient({
       appId: 'cli_0000000000000001',
       appSecret: 'test-app-secret',
       loggerLevel: 4,
       httpInstance: httpMock as any,
       autoReconnect: true,
-    });
+      ...overrides,
+    } as any);
   }
 
-  test('close() + start() during in-flight tryConnect should NOT spawn orphaned loop', async () => {
+  test('close() during an in-flight first handshake must not resurrect the client', async () => {
+    // The isStart branch of reConnect() awaits tryConnect(). A close() landing
+    // during that await used to be invisible to it: reconnectGeneration only
+    // invalidates *older* loops, and the reConnect() it calls on a retryable
+    // failure bumps the generation itself — so a closed client restarted its
+    // own retry loop, kept a non-unref'd pingLoop timer alive, and never
+    // re-armed the DataCache sweep (only start() does that).
+    const httpMock = createMockHttpInstance();
+    const client = createClient(httpMock, { handshakeTimeoutMs: 50 });
+    const priv = client as any;
+
+    client.start({ eventDispatcher: new EventDispatcher({} as any) });
+    await flushPromises();
+    expect(httpMock.pendingRequests.length).toBe(1);
+
+    httpMock.resolveNext(true);   // pullConnectConfig succeeds
+    await flushPromises();        // connect() is now waiting on the handshake
+
+    // Caller gives up while the handshake is still in flight. getWSInstance()
+    // is still null here (it is only set on 'open'), so close() cannot reach
+    // the socket — all it can do is mark the client closed.
+    client.close();
+    expect(priv.closed).toBe(true);
+
+    // Watchdog fires -> connect() resolves false -> tryConnect() returns a
+    // retryable failure -> the abandoned isStart branch resumes.
+    await delay(120);
+    await flushPromises();
+    await delay(50);
+    await flushPromises();
+
+    // No new pullConnectConfig: the retry loop was never started.
+    expect(httpMock.pendingRequests.length).toBe(0);
+    expect(httpMock.request).toHaveBeenCalledTimes(1);
+    expect(priv.reconnectInterval).toBeUndefined();
+  }, 10000);
+
+  test('a handshake that wins the race with close() is torn down, not adopted', async () => {
+    // The generation counter alone cannot handle this case: it says "someone
+    // else moved on" but not *who*, so it must leave wsConfig's socket alone.
+    // Only the explicit `closed` flag proves nobody restarted the client, which
+    // is what makes discarding the socket safe here.
     const httpMock = createMockHttpInstance();
     const client = createClient(httpMock);
-    const dispatcher = new EventDispatcher({} as any);
+    const priv = client as any;
+    const onReady = jest.fn();
+    priv.onReady = onReady;
 
-    // Step 1: Start and establish connection
-    client.start({ eventDispatcher: dispatcher });
-    expect(httpMock.pendingRequests.length).toBe(1);
-    httpMock.resolveNext(true); // pullConnectConfig succeeds
+    client.start({ eventDispatcher: new EventDispatcher({} as any) });
     await flushPromises();
-    // connect() creates MockWebSocket which emits 'open' synchronously via constructor
-    // Actually our mock doesn't auto-emit open. We need to trigger it.
-    // Let's check: connect() does `new WebSocket(url)` then listens for 'open'
-    // Our mock doesn't auto-emit. Let's fix by making connect resolve.
-    // Actually the MockWebSocket's 'open' is never emitted... Let me adjust.
+    httpMock.resolveNext(true);
+    await flushPromises();
 
-    // The wsConfig should have an instance set if connect succeeded.
-    // Since MockWebSocket doesn't emit 'open', connect() hangs.
-    // Let's take a different approach: directly test the reConnect logic
-    // by accessing private methods through type casting.
+    const MockWebSocket = jest.requireMock('ws').default;
+    const socket = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+    expect(socket).toBeDefined();
+
+    // Caller closes while the handshake is in flight...
+    client.close();
+    // ...and only then does the peer complete it.
+    socket.emit('open');
+    await flushPromises();
+    await flushPromises();
+
+    // The connection must not be adopted by a client the caller closed.
+    expect(onReady).not.toHaveBeenCalled();
+    expect(socket.terminate).toHaveBeenCalledTimes(1);
+    expect(priv.wsConfig.getWSInstance()).toBeNull();
   }, 10000);
 
   test('generation counter prevents stale loops from continuing', async () => {
@@ -610,24 +675,48 @@ describe('handshakeTimeoutMs', () => {
 
         expect(MockWebSocket.instances[instanceIndex].terminate).toHaveBeenCalledTimes(1);
         expect(http.request).toHaveBeenCalledTimes(2);
+
+        // autoReconnect is on: without this the loop keeps creating sockets
+        // (and pushing them into MockWebSocket.instances) during later tests.
+        client.close();
     }, 10000);
 
-    test('force-closing a connecting socket keeps its late error handled', async () => {
-        const http = createMockHttpInstance();
-        const client = new WSClient({
-            appId: 'cli_0000000000000001',
-            appSecret: 'secret',
-            loggerLevel: 4,
-            httpInstance: http as any,
+    // close() detaches every listener before tearing the socket down, so the
+    // error `ws` emits a tick later has nowhere to land unless a sink is left
+    // behind. Both branches — terminate() and close() — need one.
+    describe.each([
+        { label: 'force', params: { force: true }, method: 'terminate' as const },
+        { label: 'graceful', params: {}, method: 'close' as const },
+    ])('closing a connecting socket keeps its late error handled ($label)', ({ params, method }) => {
+        test('no exception escapes to the process', async () => {
+            const http = createMockHttpInstance();
+            const client = new WSClient({
+                appId: 'cli_ABCDEF0123456789',
+                appSecret: 'secret',
+                loggerLevel: 4,
+                httpInstance: http as any,
+            });
+            const MockWebSocket = jest.requireMock('ws').default;
+            const socket = new MockWebSocket();
+            (client as any).wsConfig.setWSInstance(socket);
+
+            // Assert the real guarantee explicitly. Without it the only signal
+            // is Jest's own uncaughtException handling, which can attribute the
+            // failure to whichever test happens to be running at the time.
+            const escaped: Error[] = [];
+            const collect = (err: Error) => escaped.push(err);
+            process.on('uncaughtException', collect);
+            try {
+                client.close(params);
+                await flushPromises();
+                await flushPromises();
+            } finally {
+                process.off('uncaughtException', collect);
+            }
+
+            expect(socket[method]).toHaveBeenCalledTimes(1);
+            expect(escaped).toHaveLength(0);
         });
-        const MockWebSocket = jest.requireMock('ws').default;
-        const socket = new MockWebSocket();
-        (client as any).wsConfig.setWSInstance(socket);
-
-        client.close({ force: true });
-        await flushPromises();
-
-        expect(socket.terminate).toHaveBeenCalledTimes(1);
     });
 
     test('unset handshakeTimeoutMs preserves original "no timeout" behavior', async () => {

--- a/ws-client/__tests__/reconnect.ts
+++ b/ws-client/__tests__/reconnect.ts
@@ -44,25 +44,42 @@ const flushPromises = () => new Promise<void>(r => setImmediate(r));
 // ---------------------------------------------------------------------------
 
 jest.mock('ws', () => {
+  const CONNECTING = 0;
   const OPEN = 1;
   class MockWebSocket {
+    static CONNECTING = CONNECTING;
     static OPEN = OPEN;
-    readyState = OPEN;
+    static instances: MockWebSocket[] = [];
+    readyState = CONNECTING;
     private listeners: Record<string, Function[]> = {};
+    terminate = jest.fn(() => {
+      setImmediate(() => this.emit('error', new Error('WebSocket was closed before the connection was established')));
+    });
+    constructor() {
+      MockWebSocket.instances.push(this);
+    }
     on(event: string, fn: Function) {
       (this.listeners[event] ||= []).push(fn);
+    }
+    once(event: string, fn: Function) {
+      const wrapper = (...args: any[]) => {
+        this.listeners[event] = (this.listeners[event] || []).filter(listener => listener !== wrapper);
+        fn(...args);
+      };
+      this.on(event, wrapper);
     }
     removeAllListeners() {
       this.listeners = {};
     }
     emit(event: string, ...args: any[]) {
-      (this.listeners[event] || []).forEach(fn => fn(...args));
+      const listeners = this.listeners[event] || [];
+      if (event === 'error' && listeners.length === 0) throw args[0];
+      listeners.slice().forEach(fn => fn(...args));
     }
     send(_data: any, cb?: (err?: Error) => void) {
       cb?.();
     }
     close() {}
-    terminate() {}
   }
   return { __esModule: true, default: MockWebSocket };
 });
@@ -568,8 +585,10 @@ describe('pingTimeout liveness watchdog', () => {
 // ---------------------------------------------------------------------------
 
 describe('handshakeTimeoutMs', () => {
-    test('hung handshake → terminate called, connect resolves false, retry kicks in', async () => {
+    test('hung handshake → terminate is guarded, connect resolves false, retry kicks in', async () => {
         const http = createMockHttpInstance();
+        const MockWebSocket = jest.requireMock('ws').default;
+        const instanceIndex = MockWebSocket.instances.length;
         const client = new WSClient({
             appId: 'cli_0000000000000001',
             appSecret: 'secret',
@@ -589,8 +608,27 @@ describe('handshakeTimeoutMs', () => {
         await delay(120);
         await flushPromises();
 
+        expect(MockWebSocket.instances[instanceIndex].terminate).toHaveBeenCalledTimes(1);
         expect(http.request).toHaveBeenCalledTimes(2);
     }, 10000);
+
+    test('force-closing a connecting socket keeps its late error handled', async () => {
+        const http = createMockHttpInstance();
+        const client = new WSClient({
+            appId: 'cli_0000000000000001',
+            appSecret: 'secret',
+            loggerLevel: 4,
+            httpInstance: http as any,
+        });
+        const MockWebSocket = jest.requireMock('ws').default;
+        const socket = new MockWebSocket();
+        (client as any).wsConfig.setWSInstance(socket);
+
+        client.close({ force: true });
+        await flushPromises();
+
+        expect(socket.terminate).toHaveBeenCalledTimes(1);
+    });
 
     test('unset handshakeTimeoutMs preserves original "no timeout" behavior', async () => {
         const http = createMockHttpInstance();

--- a/ws-client/index.ts
+++ b/ws-client/index.ts
@@ -324,6 +324,10 @@ export class WSClient {
         timer = setTimeout(() => {
           this.logger.error('[ws]', `handshake timeout after ${this.handshakeTimeoutMs}ms`);
           wsInstance!.removeAllListeners();
+          // `ws` emits an asynchronous error when a CONNECTING socket is
+          // terminated. Keep one listener after cleanup so the timeout does
+          // not become an uncaught exception.
+          wsInstance!.once('error', () => {});
           try { wsInstance!.terminate(); } catch { /* best effort */ }
           settleOnce(false);
         }, this.handshakeTimeoutMs);
@@ -688,6 +692,9 @@ export class WSClient {
     const wsInstance = this.wsConfig.getWSInstance();
     if (wsInstance) {
       wsInstance.removeAllListeners();
+      if (wsInstance.readyState === WebSocket.CONNECTING) {
+        wsInstance.once('error', () => {});
+      }
       if (force) {
         wsInstance.terminate();
       } else {

--- a/ws-client/index.ts
+++ b/ws-client/index.ts
@@ -43,6 +43,15 @@ export class WSClient {
 
   private isConnecting: boolean = false;
 
+  /**
+   * Set by {@link close}, cleared by {@link start}. Distinct from
+   * `reconnectGeneration`, which only invalidates *older* loops: a fresh
+   * `reConnect()` bumps the generation itself, so a closed client could
+   * resurrect its own retry loop. This flag says "this client is done"
+   * until someone starts it again.
+   */
+  private closed = false;
+
   private reconnectInfo = {
     lastConnectTime: 0,
     nextConnectTime: 0,
@@ -174,6 +183,55 @@ export class WSClient {
       clearTimeout(this.livenessTimer);
       this.livenessTimer = undefined;
     }
+  }
+
+  /**
+   * Detach a socket we are about to throw away: drop every listener, but
+   * leave one 'error' sink behind.
+   *
+   * `ws` reports the abort of a non-OPEN socket asynchronously — both
+   * `terminate()` and `close()` route through `abortHandshake()`, which
+   * emits 'error' on a later tick — and a non-force `close()` on an OPEN
+   * socket keeps the connection alive until the peer answers (up to `ws`'s
+   * 30s closeTimeout), during which a TCP reset still surfaces as 'error'.
+   * An EventEmitter with no 'error' listener throws instead of emitting, and
+   * that throw lands outside every try/catch, killing the host process.
+   * See https://github.com/larksuite/node-sdk/issues/197
+   *
+   * NOTE: not for the liveness watchdog — that one terminates *on purpose*
+   * and needs its listeners intact so 'close' drives the reconnect.
+   */
+  private detachSocket(socket: WebSocket): void {
+    socket.removeAllListeners();
+    // `on`, not `once`: the sink must outlive however many errors `ws`
+    // decides to emit, without depending on its internal de-dup latch.
+    socket.on('error', (err?: Error) => {
+      // Message only — the error may carry request details, and connectUrl
+      // is issued by pullConnectConfig and can embed a short-lived ticket.
+      this.logger.debug('[ws]', 'ignored error from discarded socket', err?.message);
+    });
+  }
+
+  /**
+   * Throw away whatever the current attempt established — socket *and* the
+   * timers its 'open' handler armed. A handshake that completes after
+   * `close()` runs `pingLoop()`, and that timer is not unref'd: leaving it
+   * behind keeps the event loop alive forever on a client the caller closed.
+   *
+   * Only safe when {@link closed} is set: otherwise a newer session may
+   * already own `wsConfig`'s instance.
+   */
+  private discardConnection(): void {
+    if (this.pingInterval) {
+      clearTimeout(this.pingInterval);
+      this.pingInterval = undefined;
+    }
+    this.clearLiveness();
+    const socket = this.wsConfig.getWSInstance();
+    if (!socket) return;
+    this.detachSocket(socket);
+    try { socket.terminate(); } catch { /* best effort */ }
+    this.wsConfig.setWSInstance(null);
   }
 
   /**
@@ -323,11 +381,7 @@ export class WSClient {
       if (this.handshakeTimeoutMs && this.handshakeTimeoutMs > 0) {
         timer = setTimeout(() => {
           this.logger.error('[ws]', `handshake timeout after ${this.handshakeTimeoutMs}ms`);
-          wsInstance!.removeAllListeners();
-          // `ws` emits an asynchronous error when a CONNECTING socket is
-          // terminated. Keep one listener after cleanup so the timeout does
-          // not become an uncaught exception.
-          wsInstance!.once('error', () => {});
+          this.detachSocket(wsInstance!);
           try { wsInstance!.terminate(); } catch { /* best effort */ }
           settleOnce(false);
         }, this.handshakeTimeoutMs);
@@ -387,6 +441,19 @@ export class WSClient {
       } finally {
         this.isConnecting = false;
       }
+      if (this.closed) {
+        // close() landed while the handshake was still in flight. Drop
+        // whatever this attempt established — nobody holds a reference to it
+        // any more — and bail out, so the reConnect() below cannot resurrect
+        // a client the caller already closed.
+        this.discardConnection();
+        return;
+      }
+      if (currentGeneration !== this.reconnectGeneration) {
+        // Superseded by a newer session, which now owns wsConfig's instance.
+        // Leave the socket alone and just stop.
+        return;
+      }
       if (result.ok) {
         this.hasEverConnected = true;
         this.safeInvoke('onReady', this.onReady);
@@ -442,6 +509,11 @@ export class WSClient {
         count++;
         this.currentReconnectAttempts = count;
         const result = await tryConnect();
+
+        if (this.closed) {
+          this.discardConnection();
+          return;
+        }
 
         // Re-check after async operation in case a new session started
         if (currentGeneration !== this.reconnectGeneration) {
@@ -675,6 +747,7 @@ export class WSClient {
    */
   close(params: { force?: boolean } = {}) {
     const { force = false } = params;
+    this.closed = true;
     // Invalidate any in-flight reconnect loops
     this.reconnectGeneration++;
     if (this.pingInterval) {
@@ -691,10 +764,7 @@ export class WSClient {
     this.currentReconnectAttempts = 0;
     const wsInstance = this.wsConfig.getWSInstance();
     if (wsInstance) {
-      wsInstance.removeAllListeners();
-      if (wsInstance.readyState === WebSocket.CONNECTING) {
-        wsInstance.once('error', () => {});
-      }
+      this.detachSocket(wsInstance);
       if (force) {
         wsInstance.terminate();
       } else {
@@ -721,6 +791,7 @@ export class WSClient {
     // Clear any terminal-error state left over from a previous session so
     // getConnectionStatus() reflects the fresh start.
     this.terminalError = false;
+    this.closed = false;
     this.currentReconnectAttempts = 0;
     // Re-arm the cache sweep in case the client was previously close()d
     // (which destroys the timer); idempotent when already running.


### PR DESCRIPTION
## Summary

- retain an error listener before terminating a WebSocket whose handshake timed out
- apply the same guard when force-closing a CONNECTING socket
- extend the WSClient regression mock to emit the late asynchronous error from `ws`

## Why

`ws` emits an asynchronous error when a CONNECTING socket is terminated.
The current cleanup removes every listener first, so that late error becomes
an uncaught exception and can terminate the host process.

This complements #203 by fixing the lower-level WSClient path described in #197.

## Verification

- `yarn jest --runTestsByPath ws-client/__tests__/reconnect.ts --runInBand`
  - 25 tests passed
- scoped TypeScript check for the changed source and test passed